### PR TITLE
Improve compound generation with dynamic programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ xenon "[Xenon][Nobelium][Nitrogen]"
 
 Phosphorous is the only one that refers to itself twice
 ```shell
-phosphorus "[Phosphorus][Hydrogen][Oxygen][Sulfur][Phosphorus][Hydrogen][Oxygen][Ruthenium][Sulfur]"
+phosphorus "[Phosphorus][Holmium][Sulfur][Phosphorus][Holmium][Ruthenium][Sulfur]"
 ```
 
 You can check this yourself using the `elements-as-a-word-list.txt` file in this repo.

--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ Here is another source of word lists in a few languages: https://github.com/lore
 Now I'm sure you're wondering if any of the names of the elements can themselves be written out using the element abbreviations. 
 
 ```shell
-silver "[Sulfur][Iodine][Livermorium][Erbium]"
-copper "[Carbon][Oxygen][Phosphorus][Phosphorus][Erbium]"
-oganesson "[Oxygen][Gallium][Nitrogen][Einsteinium][Sulfur][Oxygen][Nitrogen]"
-silicon "[Sulfur][Iodine][Lithium][Carbon][Oxygen][Nitrogen]"
+silver "[Silicon][Livermorium][Erbium]"
+copper "[Cobalt][Phosphorus][Phosphorus][Erbium]"
+oganesson "[Oxygen][Gallium][Neon][Sulfur][Sulfur][Oxygen][Nitrogen]"
 tin "[Titanium][Nitrogen]"
 ```
 
 Carbon and Xenon do it starting with their own element.
 
 ```shell
-carbon "[Carbon][Argon][Boron][Oxygen][Nitrogen]"
-xenon "[Xenon][Nitrogen][Oxygen][Nitrogen]"
+silicon "[Silicon][Lithium][Cobalt][Nitrogen]"
+carbon "[Calcium][Rubidium][Oxygen][Nitrogen]"
+xenon "[Xenon][Nobelium][Nitrogen]"
 ```
 
 Phosphorous is the only one that refers to itself twice
@@ -60,12 +60,12 @@ If you're writing a Chemistry textbook, I bet you could find a way to use this f
 
 ```shell
 Chemistry is brew "[Boron][Rhenium][Tungsten]"
-Chemistry is concoction "[Carbon][Oxygen][Nitrogen][Carbon][Oxygen][Carbon][Titanium][Oxygen][Nitrogen]"
+Chemistry is concoction "[Cobalt][Nitrogen][Cobalt][Carbon][Titanium][Oxygen][Nitrogen]"
 Chemistry is dynamite "[Dysprosium][Nitrogen][Americium][Iodine][Tellurium]"
-Chemistry is fractionation "[Fluorine][Radium][Carbon][Titanium][Oxygen][Nitrogen][Astatine][Iodine][Oxygen][Nitrogen]"
-Chemistry is gasses "[Gallium][Sulfur][Sulfur][Einsteinium]"
-Chemistry is esterases "[Einsteinium][Tellurium][Radium][Sulfur][Einsteinium]"
-Chemistry is pressure "[Phosphorus][Rhenium][Sulfur][Sulfur][Uranium][Rhenium]"
+Chemistry is fractionation "[Francium][Actinium][Titanium][Oxygen][Sodium][Titanium][Oxygen][Nitrogen]"
+Chemistry is gasses "[Gallium][Sulfur][Selenium][Sulfur]"
+Chemistry is esterases "[Einsteinium][Tellurium][Radium][Selenium][Sulfur]"
+Chemistry is pressure "[Praseodymium][Einsteinium][Sulfur][Uranium][Rhenium]"
 Chemistry is salts "[Sulfur][Aluminium][Tennessine]"
 Chemistry is the solution "[Sulfur][Oxygen][Lutetium][Titanium][Oxygen][Nitrogen]"
 Chemistry is synthesis "[Sulfur][Yttrium][Nitrogen][Thorium][Einsteinium][Iodine][Sulfur]"
@@ -73,11 +73,11 @@ Chemistry is oversaturation "[Oxygen][Vanadium][Erbium][Sulfur][Astatine][Uraniu
 Chemistry is supersaturate "[Sulfur][Uranium][Phosphorus][Erbium][Sulfur][Astatine][Uranium][Radium][Tellurium]"
 Chemistry is alkali "[Aluminium][Potassium][Aluminium][Iodine]"
 Chemistry is catalytic "[Carbon][Astatine][Aluminium][Yttrium][Titanium][Carbon]"
-Chemistry is cationic "[Carbon][Astatine][Iodine][Oxygen][Nitrogen][Iodine][Carbon]"
-Chemistry is calculation "[Carbon][Aluminium][Carbon][Uranium][Lanthanum][Titanium][Oxygen][Nitrogen]"
-Chemistry is calibration "[Carbon][Aluminium][Iodine][Boron][Radium][Titanium][Oxygen][Nitrogen]"
-Chemistry is carcinogenic "[Carbon][Argon][Carbon][Iodine][Nitrogen][Oxygen][Germanium][Nitrogen][Iodine][Carbon]"
-Chemistry is catalysis "[Carbon][Astatine][Aluminium][Yttrium][Sulfur][Iodine][Sulfur]"
+Chemistry is cationic "[Calcium][Titanium][Oxygen][Nickel][Carbon]"
+Chemistry is calculation "[Carbon][Aluminium][Copper][Lanthanum][Titanium][Oxygen][Nitrogen]"
+Chemistry is calibration "[Calcium][Lithium][Bromine][Astatine][Iodine][Oxygen][Nitrogen]"
+Chemistry is carcinogenic "[Carbon][Argon][Carbon][Indium][Oxygen][Germanium][Nickel][Carbon]"
+Chemistry is catalysis "[Carbon][Astatine][Aluminium][Yttrium][Silicon][Sulfur]"
 ```
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
+use maplit::hashmap;
+use std::collections::HashMap;
 use std::fmt;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use structopt::StructOpt;
-use std::collections::HashMap;
-use maplit::hashmap;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
@@ -32,7 +32,6 @@ fn main() {
     } else {
         println!("USAGE: `periodic-words -w <single-word>` or `periodic-words -f <file>`");
     }
-
 }
 
 struct Compound(pub Vec<String>);
@@ -52,166 +51,251 @@ impl fmt::Display for Compound {
 }
 
 struct PeriodicWords {
-    periodic_elements: HashMap<&'static str, &'static str>
+    periodic_elements: HashMap<&'static str, &'static str>,
 }
 
 impl PeriodicWords {
-
     fn new() -> Self {
         Self {
             periodic_elements: hashmap! {
-       "ac" => "Actinium",
-       "ag" => "Silver",
-       "al" => "Aluminium",
-       "am" => "Americium",
-       "ar" => "Argon",
-       "as" => "Arsenic",
-       "at" => "Astatine",
-       "au" => "Gold",
-       "b" => "Boron",
-       "ba" => "Barium",
-       "be" => "Beryllium",
-       "bh" => "Bohrium",
-       "bi" => "Bismuth",
-       "bk" => "Berkelium",
-       "br" => "Bromine",
-       "c" => "Carbon",
-       "ca" => "Calcium",
-       "cd" => "Cadmium",
-       "ce" => "Cerium",
-       "cf" => "Californium",
-       "cl" => "Chlorine",
-       "cm" => "Curium",
-       "cn" => "Copernicium",
-       "co" => "Cobalt",
-       "cr" => "Chromium",
-       "cs" => "Caesium",
-       "cu" => "Copper",
-       "db" => "Dubnium",
-       "ds" => "Darmstadtium",
-       "dy" => "Dysprosium",
-       "er" => "Erbium",
-       "es" => "Einsteinium",
-       "eu" => "Europium",
-       "f" => "Fluorine",
-       "fe" => "Iron",
-       "fl" => "Flerovium",
-       "fm" => "Fermium",
-       "fr" => "Francium",
-       "ga" => "Gallium",
-       "gd" => "Gadolinium",
-       "ge" => "Germanium",
-       "h" => "Hydrogen",
-       "he" => "Helium",
-       "hf" => "Hafnium",
-       "hg" => "Mercury",
-       "ho" => "Holmium",
-       "hs" => "Hassium",
-       "i" => "Iodine",
-       "in" => "Indium",
-       "ir" => "Iridium",
-       "k" => "Potassium",
-       "kr" => "Krypton",
-       "la" => "Lanthanum",
-       "li" => "Lithium",
-       "lr" => "Lawrencium",
-       "lu" => "Lutetium",
-       "lv" => "Livermorium",
-       "mc" => "Moscovium",
-       "md" => "Mendelevium",
-       "mg" => "Magnesium",
-       "mn" => "Manganese",
-       "mo" => "Molybdenum",
-       "mt" => "Meitnerium",
-       "n" => "Nitrogen",
-       "na" => "Sodium",
-       "nb" => "Niobium",
-       "nd" => "Neodymium",
-       "ne" => "Neon",
-       "nh" => "Nihonium",
-       "ni" => "Nickel",
-       "no" => "Nobelium",
-       "np" => "Neptunium",
-       "o" => "Oxygen",
-       "og" => "Oganesson",
-       "os" => "Osmium",
-       "p" => "Phosphorus",
-       "pa" => "Protactinium",
-       "pb" => "Lead",
-       "pd" => "Palladium",
-       "pm" => "Promethium",
-       "po" => "Polonium",
-       "pr" => "Praseodymium",
-       "pt" => "Platinum",
-       "pu" => "Plutonium",
-       "ra" => "Radium",
-       "rb" => "Rubidium",
-       "re" => "Rhenium",
-       "rf" => "Rutherfordium",
-       "rg" => "Roentgenium",
-       "rh" => "Rhodium",
-       "rn" => "Radon",
-       "ru" => "Ruthenium",
-       "s" => "Sulfur",
-       "sb" => "Antimony",
-       "sc" => "Scandium",
-       "se" => "Selenium",
-       "sg" => "Seaborgium",
-       "si" => "Silicon",
-       "sm" => "Samarium",
-       "sn" => "Tin",
-       "sr" => "Strontium",
-       "ta" => "Tantalum",
-       "tb" => "Terbium",
-       "tc" => "Technetium",
-       "te" => "Tellurium",
-       "th" => "Thorium",
-       "ti" => "Titanium",
-       "tl" => "Thallium",
-       "tm" => "Thulium",
-       "ts" => "Tennessine",
-       "u" => "Uranium",
-       "v" => "Vanadium",
-       "w" => "Tungsten",
-       "xe" => "Xenon",
-       "y" => "Yttrium",
-       "yb" => "Ytterbium",
-       "zn" => "Zinc",
-       "zr" => "Zirconium",
-    }
+               "ac" => "Actinium",
+               "ag" => "Silver",
+               "al" => "Aluminium",
+               "am" => "Americium",
+               "ar" => "Argon",
+               "as" => "Arsenic",
+               "at" => "Astatine",
+               "au" => "Gold",
+               "b" => "Boron",
+               "ba" => "Barium",
+               "be" => "Beryllium",
+               "bh" => "Bohrium",
+               "bi" => "Bismuth",
+               "bk" => "Berkelium",
+               "br" => "Bromine",
+               "c" => "Carbon",
+               "ca" => "Calcium",
+               "cd" => "Cadmium",
+               "ce" => "Cerium",
+               "cf" => "Californium",
+               "cl" => "Chlorine",
+               "cm" => "Curium",
+               "cn" => "Copernicium",
+               "co" => "Cobalt",
+               "cr" => "Chromium",
+               "cs" => "Caesium",
+               "cu" => "Copper",
+               "db" => "Dubnium",
+               "ds" => "Darmstadtium",
+               "dy" => "Dysprosium",
+               "er" => "Erbium",
+               "es" => "Einsteinium",
+               "eu" => "Europium",
+               "f" => "Fluorine",
+               "fe" => "Iron",
+               "fl" => "Flerovium",
+               "fm" => "Fermium",
+               "fr" => "Francium",
+               "ga" => "Gallium",
+               "gd" => "Gadolinium",
+               "ge" => "Germanium",
+               "h" => "Hydrogen",
+               "he" => "Helium",
+               "hf" => "Hafnium",
+               "hg" => "Mercury",
+               "ho" => "Holmium",
+               "hs" => "Hassium",
+               "i" => "Iodine",
+               "in" => "Indium",
+               "ir" => "Iridium",
+               "k" => "Potassium",
+               "kr" => "Krypton",
+               "la" => "Lanthanum",
+               "li" => "Lithium",
+               "lr" => "Lawrencium",
+               "lu" => "Lutetium",
+               "lv" => "Livermorium",
+               "mc" => "Moscovium",
+               "md" => "Mendelevium",
+               "mg" => "Magnesium",
+               "mn" => "Manganese",
+               "mo" => "Molybdenum",
+               "mt" => "Meitnerium",
+               "n" => "Nitrogen",
+               "na" => "Sodium",
+               "nb" => "Niobium",
+               "nd" => "Neodymium",
+               "ne" => "Neon",
+               "nh" => "Nihonium",
+               "ni" => "Nickel",
+               "no" => "Nobelium",
+               "np" => "Neptunium",
+               "o" => "Oxygen",
+               "og" => "Oganesson",
+               "os" => "Osmium",
+               "p" => "Phosphorus",
+               "pa" => "Protactinium",
+               "pb" => "Lead",
+               "pd" => "Palladium",
+               "pm" => "Promethium",
+               "po" => "Polonium",
+               "pr" => "Praseodymium",
+               "pt" => "Platinum",
+               "pu" => "Plutonium",
+               "ra" => "Radium",
+               "rb" => "Rubidium",
+               "re" => "Rhenium",
+               "rf" => "Rutherfordium",
+               "rg" => "Roentgenium",
+               "rh" => "Rhodium",
+               "rn" => "Radon",
+               "ru" => "Ruthenium",
+               "s" => "Sulfur",
+               "sb" => "Antimony",
+               "sc" => "Scandium",
+               "se" => "Selenium",
+               "sg" => "Seaborgium",
+               "si" => "Silicon",
+               "sm" => "Samarium",
+               "sn" => "Tin",
+               "sr" => "Strontium",
+               "ta" => "Tantalum",
+               "tb" => "Terbium",
+               "tc" => "Technetium",
+               "te" => "Tellurium",
+               "th" => "Thorium",
+               "ti" => "Titanium",
+               "tl" => "Thallium",
+               "tm" => "Thulium",
+               "ts" => "Tennessine",
+               "u" => "Uranium",
+               "v" => "Vanadium",
+               "w" => "Tungsten",
+               "xe" => "Xenon",
+               "y" => "Yttrium",
+               "yb" => "Ytterbium",
+               "zn" => "Zinc",
+               "zr" => "Zirconium",
+            },
         }
+    }
+
+    fn gen_compound(&self, s: &str) -> Option<Vec<&'static str>> {
+        assert!(s.is_ascii());
+        let len = s.len();
+        let mut sol = vec![None; s.len() + 1];
+        // init recurrence-relation base cases
+        // end of the string is a valid solution
+        sol[len] = Some(vec![]);
+        if let Some(&elem) = self.periodic_elements.get(&s[(len - 1)..]) {
+            sol[len - 1] = Some(vec![elem])
+        }
+
+        for i in (0..(len - 1)).rev() {
+            let fst_sol = &sol[i + 1];
+            let snd_sol = &sol[i + 2];
+            let fst = self.periodic_elements.get(&s[i..(i + 1)]);
+            let snd = self.periodic_elements.get(&s[i..(i + 2)]);
+            match (fst_sol, fst, snd_sol, snd) {
+                (Some(fst_sol), Some(&elem_one), Some(snd_sol), Some(&elem_two)) => {
+                    // favor shorter compounds
+                    sol[i] = Some(if fst_sol.len() < snd_sol.len() {
+                        appended_vec(fst_sol, elem_one)
+                    } else {
+                        appended_vec(snd_sol, elem_two)
+                    })
+                }
+                (Some(prev_sol), Some(&elem), _, _) | (_, _, Some(prev_sol), Some(&elem)) => {
+                    sol[i] = Some(appended_vec(prev_sol, elem))
+                }
+                // item already init to None, continue
+                _ => (),
+            }
+        }
+
+        sol[0]
+            .take()
+            .map(|s| s.into_iter().rev().collect::<Vec<_>>())
     }
 
     fn print_matches(&self, line: String, show_misses: bool) {
-        let mut full_match = true;
-        let mut prev_was_double = false;
-        let mut compound = Compound(Vec::new());
-        for n in 0..line.to_lowercase().chars().count() {
-            if prev_was_double {
-                prev_was_double = false;
-                continue;
-            }
-            let this_char = line.chars().nth(n).unwrap_or('?');
-            let next_char = line.chars().nth(n + 1).unwrap_or('*');
-            let mut the_double: String = "".to_string();
-            the_double.push(this_char);
-            the_double.push(next_char);
-            let mut the_single: String = "".to_string();
-            the_single.push(this_char);
-
-            if let Some(single) = self.periodic_elements.get(the_single.as_str()) {
-                compound.push(single.to_string());
-            } else if let Some(double) = self.periodic_elements.get(the_double.as_str()) {
-                compound.push(double.to_string());
-                prev_was_double = true;
-            } else {
-                full_match = false;
-            }
-        }
-        if full_match {
+        let maybe_compound = self.gen_compound(line.as_str());
+        if let Some(compound) = maybe_compound {
+            let compound = Compound(compound.into_iter().map(ToString::to_string).collect());
             println!("{} {}", line, compound);
         } else if show_misses {
-            println!("\"{}\" can't be written with the periodic table until we discover more elements.", line);
+            println!(
+                "\"{}\" can't be written with the periodic table until we discover more elements.",
+                line
+            );
         }
+    }
+}
+
+#[inline]
+fn appended_vec(base_vec: &Vec<&'static str>, elem: &'static str) -> Vec<&'static str> {
+    let mut vec = base_vec.clone();
+    vec.push(elem);
+    vec
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PeriodicWords;
+
+    #[test]
+    fn dyn_chemical_compound_works() {
+        let test = PeriodicWords::new();
+        assert_eq!(
+            test.gen_compound("farts"),
+            Some(vec!["Fluorine", "Argon", "Tennessine"])
+        );
+        assert_eq!(
+            test.gen_compound("fun"),
+            Some(vec!["Fluorine", "Uranium", "Nitrogen"])
+        );
+        assert_eq!(
+            test.gen_compound("brew"),
+            Some(vec!["Boron", "Rhenium", "Tungsten"])
+        );
+        assert_eq!(test.gen_compound("ew"), None);
+        assert_eq!(
+            test.gen_compound("carbon"),
+            Some(vec!["Calcium", "Rubidium", "Oxygen", "Nitrogen"])
+        );
+        assert_eq!(
+            test.gen_compound("xenon"),
+            Some(vec!["Xenon", "Nobelium", "Nitrogen"])
+        );
+        assert_eq!(
+            test.gen_compound("silver"),
+            Some(vec!["Silicon", "Livermorium", "Erbium"])
+        );
+        assert_eq!(
+            test.gen_compound("oganesson"),
+            Some(vec![
+                "Oxygen", "Gallium", "Neon", "Sulfur", "Sulfur", "Oxygen", "Nitrogen"
+            ])
+        );
+        assert_eq!(
+            test.gen_compound("copper"),
+            Some(vec!["Cobalt", "Phosphorus", "Phosphorus", "Erbium"])
+        );
+        assert_eq!(
+            test.gen_compound("silicon"),
+            Some(vec!["Silicon", "Lithium", "Cobalt", "Nitrogen"])
+        );
+        assert_eq!(test.gen_compound("tin"), Some(vec!["Titanium", "Nitrogen"]));
+        assert_eq!(
+            test.gen_compound("dynamite"),
+            Some(vec![
+                "Dysprosium",
+                "Nitrogen",
+                "Americium",
+                "Iodine",
+                "Tellurium"
+            ])
+        );
+        assert_eq!(test.gen_compound("zummer"), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,7 @@ impl PeriodicWords {
     }
 
     fn print_matches(&self, line: String, show_misses: bool) {
+        let line = line.to_ascii_lowercase();
         let maybe_compound = self.gen_compound(line.as_str());
         if let Some(compound) = maybe_compound {
             let compound = Compound(compound.into_iter().map(ToString::to_string).collect());

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,19 +34,14 @@ fn main() {
     }
 }
 
-struct Compound(pub Vec<String>);
-
-impl Compound {
-    fn push(&mut self, value: String) {
-        self.0.push(value)
-    }
-}
+struct Compound(pub Vec<&'static str>);
 
 impl fmt::Display for Compound {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.iter().fold(Ok(()), |result, element| {
-            result.and_then(|_| write!(f, "[{}]", element))
-        })
+        for element in &self.0 {
+            write!(f, "[{}]", element)?;
+        }
+        Ok(())
     }
 }
 
@@ -222,7 +217,7 @@ impl PeriodicWords {
         let line = line.to_ascii_lowercase();
         let maybe_compound = self.gen_compound(line.as_str());
         if let Some(compound) = maybe_compound {
-            let compound = Compound(compound.into_iter().map(ToString::to_string).collect());
+            let compound = Compound(compound);
             println!("{} {}", line, compound);
         } else if show_misses {
             println!(


### PR DESCRIPTION
Hello, checked out your repo when [rustlang](https://twitter.com/rustlang) retweeted it. Thought it was a cool idea and wanted to help improve it.

Pros:
- runs faster with larger inputs O(N) algorithm rather than O(N^2) due to sub-optimal string indexing with `line.chars().nth(n)`
- Generates shorter compounds
- Avoids some allocations at the cost of limiting output to only static string slices

Cons:
- Uses more memory (O(N *  shortest compound length))
- because of using dynamic programming, the recurrence relation relies on ascii string indices, limiting the input
- negligible performance improvement on smaller inputs

This is the bench mark of running with `words_alpha.txt` from https://github.com/dwyl/english-words . Both built with `cargo build --release`

```shell
raze@sol~/P/periodic-words> git branch
  dyn-programming-solution
* main
raze@sol~/P/periodic-words> time target/release/periodic-words -f word-lists/words_alpha.txt

________________________________________________________
Executed in    1.04 secs    fish           external
   usr time    1.04 secs  475.00 micros    1.04 secs
   sys time    0.01 secs  115.00 micros    0.00 secs

raze@sol~/P/periodic-words> git checkout dyn-programming-solution 
Switched to branch 'dyn-programming-solution'
raze@sol~/P/periodic-words> cargo build --release
   Compiling periodic-words v0.1.0 (/home/raze/Projects/periodic-words)
    Finished release [optimized] target(s) in 1.81s
raze@sol~/P/periodic-words> time target/release/periodic-words -f word-lists/words_alpha.txt

________________________________________________________
Executed in  423.49 millis    fish           external
   usr time  421.47 millis  396.00 micros  421.08 millis
   sys time    2.10 millis   98.00 micros    2.00 millis

```